### PR TITLE
Feature/filtering and sorting

### DIFF
--- a/src/contactmomenten/api/filters.py
+++ b/src/contactmomenten/api/filters.py
@@ -15,7 +15,11 @@ from contactmomenten.datamodel.models import (
 class ObjectContactMomentFilter(FilterSet):
     class Meta:
         model = ObjectContactMoment
-        fields = ("object", "contactmoment")
+        fields = (
+            "object",
+            "contactmoment",
+            "object_type",
+        )
 
 
 class ContactMomentFilter(FilterSet):
@@ -40,13 +44,13 @@ class ContactMomentFilter(FilterSet):
     class Meta:
         model = ContactMoment
         fields = {
-            "voorkeurstaal": ["exact"],
             "vorig_contactmoment": ["exact"],
             "volgend_contactmoment": ["exact"],
             "bronorganisatie": ["exact"],
             "registratiedatum": ["exact", "gt", "gte", "lt", "lte"],
             "kanaal": ["exact"],
             "voorkeurskanaal": ["exact"],
+            "voorkeurstaal": ["exact"],
             "initiatiefnemer": ["exact"],
             "medewerker": ["exact"],
             "ordering": ["exact"],

--- a/src/contactmomenten/api/tests/test_objectcontactmoment.py
+++ b/src/contactmomenten/api/tests/test_objectcontactmoment.py
@@ -196,6 +196,15 @@ class ObjectContactMomentFilterTests(JWTAuthMixin, APITestCase):
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["object"], oio.object)
 
+    def test_filter_object_type(self):
+        oio = ObjectContactMomentFactory.create(object_type=ObjectTypes.zaak)
+
+        response = self.client.get(self.list_url, {"objectType": ObjectTypes.zaak})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["object_type"], ObjectTypes.zaak)
+
     def test_pagination_default(self):
         ObjectContactMomentFactory.create_batch(2)
         url = reverse(ObjectContactMoment)

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -87,13 +87,6 @@ paths:
       summary: Alle CONTACTMOMENTen opvragen.
       description: Alle CONTACTMOMENTen opvragen.
       parameters:
-      - name: voorkeurstaal
-        in: query
-        description: 'Een ISO 639-2/B taalcode waarin de inhoud van het INFORMATIEOBJECT
-          is vastgelegd. Voorbeeld: `nld`. Zie: https://www.iso.org/standard/4767.html'
-        required: false
-        schema:
-          type: string
       - name: vorigContactmoment
         in: query
         description: URL-referentie naar het vorige CONTACTMOMENT.
@@ -156,6 +149,13 @@ paths:
         in: query
         description: Het communicatiekanaal dat voor opvolging van de klantinteractie
           de voorkeur heeft van de KLANT.
+        required: false
+        schema:
+          type: string
+      - name: voorkeurstaal
+        in: query
+        description: 'Een ISO 639-2/B taalcode waarin de inhoud van het INFORMATIEOBJECT
+          is vastgelegd. Voorbeeld: `nld`. Zie: https://www.iso.org/standard/4767.html'
         required: false
         schema:
           type: string
@@ -2108,6 +2108,14 @@ paths:
         schema:
           type: string
           format: uri
+      - name: objectType
+        in: query
+        description: Het type van het gerelateerde OBJECT.
+        required: false
+        schema:
+          type: string
+          enum:
+          - zaak
       - name: page
         in: query
         description: Een pagina binnen de gepagineerde set resultaten.

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -40,13 +40,6 @@
                 "description": "Alle CONTACTMOMENTen opvragen.",
                 "parameters": [
                     {
-                        "name": "voorkeurstaal",
-                        "in": "query",
-                        "description": "Een ISO 639-2/B taalcode waarin de inhoud van het INFORMATIEOBJECT is vastgelegd. Voorbeeld: `nld`. Zie: https://www.iso.org/standard/4767.html",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
                         "name": "vorigContactmoment",
                         "in": "query",
                         "description": "URL-referentie naar het vorige CONTACTMOMENT.",
@@ -115,6 +108,13 @@
                         "name": "voorkeurskanaal",
                         "in": "query",
                         "description": "Het communicatiekanaal dat voor opvolging van de klantinteractie de voorkeur heeft van de KLANT.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "voorkeurstaal",
+                        "in": "query",
+                        "description": "Een ISO 639-2/B taalcode waarin de inhoud van het INFORMATIEOBJECT is vastgelegd. Voorbeeld: `nld`. Zie: https://www.iso.org/standard/4767.html",
                         "required": false,
                         "type": "string"
                     },
@@ -2457,6 +2457,16 @@
                         "required": false,
                         "type": "string",
                         "format": "uri"
+                    },
+                    {
+                        "name": "objectType",
+                        "in": "query",
+                        "description": "Het type van het gerelateerde OBJECT.",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "zaak"
+                        ]
                     },
                     {
                         "name": "page",


### PR DESCRIPTION
Issue: https://github.com/VNG-Realisatie/gemma-zaken/issues/1633
added  missing `ObjectContactMoment.objectType` filter

@joeribekker the suggested API spec ([here](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/HenriKorver/gemma-zaken/master/api-specificatie/DESIGN/kic/contactmomenten/openapi.yaml#operation/contactmoment_list)) has a `contactmoment` query parameter on the `ContactMoment`en list endpoint. Is this needed? I'm not sure why you would want to filter a list endpoint if you already have the URLs of the individual `ContactMoment`en